### PR TITLE
add ghazi weapon siege bonus and add militia cost workaround

### DIFF
--- a/src/attrib/workarounds.ts
+++ b/src/attrib/workarounds.ts
@@ -339,6 +339,13 @@ workaround("Modify King scaling to be more descriptive", {
   },
 });
 
+workaround("Modify Militia cost to 20", {
+  predicate: (item) => item.baseId == "militia",
+  mutator: (item) => {
+    item.costs = MILITIA_COSTS;
+  },
+});
+
 workaround("Modify Militia scaling to be more descriptive", {
   predicate: (item) => item.attribName?.startsWith("upgrade_militia_") || false,
   mutator: (item) => {
@@ -508,6 +515,7 @@ workaround("HRE Civ Bonus: 'Cost of emplacements on Outposts, Wall Towers, and K
 });
 
 const NO_COSTS = { gold: 0, wood: 0, food: 0, stone: 0, total: 0, time: 0 };
+const MILITIA_COSTS = { gold: 0, wood: 0, food: 20, stone: 0, total: 20, time: 0, popcap: 1 };
 
 function discountCosts(costs: Item["costs"], discount: number) {
   const newCosts = {

--- a/units/all-optimized.json
+++ b/units/all-optimized.json
@@ -14991,6 +14991,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -15079,6 +15092,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -15160,6 +15186,19 @@
                   },
                   "effect": "change",
                   "value": 18,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
                   "type": "passive"
                 },
                 {
@@ -22155,13 +22194,13 @@
           ],
           "unique": false,
           "costs": {
-            "food": 0,
-            "wood": 0,
-            "stone": 0,
             "gold": 0,
-            "total": 0,
-            "popcap": 1,
-            "time": 0
+            "wood": 0,
+            "food": 20,
+            "stone": 0,
+            "total": 20,
+            "time": 0,
+            "popcap": 1
           },
           "producedBy": [],
           "icon": "https://data.aoe4world.com/images/units/militia-2.png",

--- a/units/all-unified.json
+++ b/units/all-unified.json
@@ -32416,6 +32416,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -32540,6 +32553,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -32657,6 +32683,19 @@
                   },
                   "effect": "change",
                   "value": 18,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
                   "type": "passive"
                 },
                 {
@@ -40680,13 +40719,13 @@
           ],
           "unique": false,
           "costs": {
-            "food": 0,
-            "wood": 0,
-            "stone": 0,
             "gold": 0,
-            "total": 0,
-            "popcap": 1,
-            "time": 0
+            "wood": 0,
+            "food": 20,
+            "stone": 0,
+            "total": 20,
+            "time": 0,
+            "popcap": 1
           },
           "producedBy": [],
           "icon": "https://data.aoe4world.com/images/units/militia-2.png",

--- a/units/all.json
+++ b/units/all.json
@@ -16643,6 +16643,19 @@
               "target": {
                 "class": [
                   [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
                     "heavy"
                   ]
                 ]
@@ -16767,6 +16780,19 @@
               "target": {
                 "class": [
                   [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
                     "heavy"
                   ]
                 ]
@@ -16884,6 +16910,19 @@
               },
               "effect": "change",
               "value": 18,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
               "type": "passive"
             },
             {
@@ -37359,13 +37398,13 @@
       ],
       "unique": false,
       "costs": {
-        "food": 0,
-        "wood": 0,
-        "stone": 0,
         "gold": 0,
-        "total": 0,
-        "popcap": 1,
-        "time": 0
+        "wood": 0,
+        "food": 20,
+        "stone": 0,
+        "total": 20,
+        "time": 0,
+        "popcap": 1
       },
       "producedBy": [],
       "icon": "https://data.aoe4world.com/images/units/militia-2.png",

--- a/units/delhi-optimized.json
+++ b/units/delhi-optimized.json
@@ -1281,6 +1281,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -1369,6 +1382,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -1450,6 +1476,19 @@
                   },
                   "effect": "change",
                   "value": 18,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
                   "type": "passive"
                 },
                 {

--- a/units/delhi-unified.json
+++ b/units/delhi-unified.json
@@ -1357,6 +1357,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -1481,6 +1494,19 @@
                   "target": {
                     "class": [
                       [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
                         "heavy"
                       ]
                     ]
@@ -1598,6 +1624,19 @@
                   },
                   "effect": "change",
                   "value": 18,
+                  "type": "passive"
+                },
+                {
+                  "property": "meleeAttack",
+                  "target": {
+                    "class": [
+                      [
+                        "siege"
+                      ]
+                    ]
+                  },
+                  "effect": "change",
+                  "value": 10,
                   "type": "passive"
                 },
                 {

--- a/units/delhi.json
+++ b/units/delhi.json
@@ -1146,6 +1146,19 @@
               "target": {
                 "class": [
                   [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
                     "heavy"
                   ]
                 ]
@@ -1270,6 +1283,19 @@
               "target": {
                 "class": [
                   [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
                     "heavy"
                   ]
                 ]
@@ -1387,6 +1413,19 @@
               },
               "effect": "change",
               "value": 18,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
               "type": "passive"
             },
             {

--- a/units/delhi/ghazi-raider-2.json
+++ b/units/delhi/ghazi-raider-2.json
@@ -62,6 +62,19 @@
           "target": {
             "class": [
               [
+                "siege"
+              ]
+            ]
+          },
+          "effect": "change",
+          "value": 10,
+          "type": "passive"
+        },
+        {
+          "property": "meleeAttack",
+          "target": {
+            "class": [
+              [
                 "heavy"
               ]
             ]

--- a/units/delhi/ghazi-raider-3.json
+++ b/units/delhi/ghazi-raider-3.json
@@ -62,6 +62,19 @@
           "target": {
             "class": [
               [
+                "siege"
+              ]
+            ]
+          },
+          "effect": "change",
+          "value": 10,
+          "type": "passive"
+        },
+        {
+          "property": "meleeAttack",
+          "target": {
+            "class": [
+              [
                 "heavy"
               ]
             ]

--- a/units/delhi/ghazi-raider-4.json
+++ b/units/delhi/ghazi-raider-4.json
@@ -62,6 +62,19 @@
           "target": {
             "class": [
               [
+                "siege"
+              ]
+            ]
+          },
+          "effect": "change",
+          "value": 10,
+          "type": "passive"
+        },
+        {
+          "property": "meleeAttack",
+          "target": {
+            "class": [
+              [
                 "heavy"
               ]
             ]

--- a/units/rus-optimized.json
+++ b/units/rus-optimized.json
@@ -2497,13 +2497,13 @@
           ],
           "unique": false,
           "costs": {
-            "food": 0,
-            "wood": 0,
-            "stone": 0,
             "gold": 0,
-            "total": 0,
-            "popcap": 1,
-            "time": 0
+            "wood": 0,
+            "food": 20,
+            "stone": 0,
+            "total": 20,
+            "time": 0,
+            "popcap": 1
           },
           "producedBy": [],
           "icon": "https://data.aoe4world.com/images/units/militia-2.png",

--- a/units/rus-unified.json
+++ b/units/rus-unified.json
@@ -2781,13 +2781,13 @@
           ],
           "unique": false,
           "costs": {
-            "food": 0,
-            "wood": 0,
-            "stone": 0,
             "gold": 0,
-            "total": 0,
-            "popcap": 1,
-            "time": 0
+            "wood": 0,
+            "food": 20,
+            "stone": 0,
+            "total": 20,
+            "time": 0,
+            "popcap": 1
           },
           "producedBy": [],
           "icon": "https://data.aoe4world.com/images/units/militia-2.png",

--- a/units/rus.json
+++ b/units/rus.json
@@ -2420,13 +2420,13 @@
       ],
       "unique": false,
       "costs": {
-        "food": 0,
-        "wood": 0,
-        "stone": 0,
         "gold": 0,
-        "total": 0,
-        "popcap": 1,
-        "time": 0
+        "wood": 0,
+        "food": 20,
+        "stone": 0,
+        "total": 20,
+        "time": 0,
+        "popcap": 1
       },
       "producedBy": [],
       "icon": "https://data.aoe4world.com/images/units/militia-2.png",

--- a/units/rus/militia-2.json
+++ b/units/rus/militia-2.json
@@ -20,13 +20,13 @@
   ],
   "unique": false,
   "costs": {
-    "food": 0,
-    "wood": 0,
-    "stone": 0,
     "gold": 0,
-    "total": 0,
-    "popcap": 1,
-    "time": 0
+    "wood": 0,
+    "food": 20,
+    "stone": 0,
+    "total": 20,
+    "time": 0,
+    "popcap": 1
   },
   "producedBy": [],
   "icon": "https://data.aoe4world.com/images/units/militia-2.png",

--- a/units/unified/ghazi-raider.json
+++ b/units/unified/ghazi-raider.json
@@ -84,6 +84,19 @@
               "target": {
                 "class": [
                   [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
                     "heavy"
                   ]
                 ]
@@ -208,6 +221,19 @@
               "target": {
                 "class": [
                   [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
                     "heavy"
                   ]
                 ]
@@ -325,6 +351,19 @@
               },
               "effect": "change",
               "value": 18,
+              "type": "passive"
+            },
+            {
+              "property": "meleeAttack",
+              "target": {
+                "class": [
+                  [
+                    "siege"
+                  ]
+                ]
+              },
+              "effect": "change",
+              "value": 10,
               "type": "passive"
             },
             {

--- a/units/unified/militia.json
+++ b/units/unified/militia.json
@@ -42,13 +42,13 @@
       ],
       "unique": false,
       "costs": {
-        "food": 0,
-        "wood": 0,
-        "stone": 0,
         "gold": 0,
-        "total": 0,
-        "popcap": 1,
-        "time": 0
+        "wood": 0,
+        "food": 20,
+        "stone": 0,
+        "total": 20,
+        "time": 0,
+        "popcap": 1
       },
       "producedBy": [],
       "icon": "https://data.aoe4world.com/images/units/militia-2.png",


### PR DESCRIPTION
this PR is two fold

- implement a workaround to modify militia cost = 20
- update siege dmg weapon modifiers for ghazi that i was catching in my latest source

if you don't agree with the militia cost, i can retract it and just submit ghazi siege bonus modifier.