### PR TITLE
Set Ghazi Raider attack bonus as pro instead of con

### DIFF
--- a/units/delhi/ghazi-raider-2.json
+++ b/units/delhi/ghazi-raider-2.json
@@ -9,7 +9,7 @@
   "civs": [
     "de"
   ],
-  "description": "Fast cavalry effective at raiding, flanking, and countering ranged units.\n+ High movement speed\n- Increased effectiveness against armored units\n- Countered by Spearmen",
+  "description": "Fast cavalry effective at raiding, flanking, and countering ranged units.\n+ High movement speed\n+ Increased effectiveness against armored units\n- Countered by Spearmen",
   "classes": [
     "light",
     "melee",

--- a/units/delhi/ghazi-raider-3.json
+++ b/units/delhi/ghazi-raider-3.json
@@ -9,7 +9,7 @@
   "civs": [
     "de"
   ],
-  "description": "Fast cavalry effective at raiding, flanking, and countering ranged units.\n+ High movement speed\n- Increased effectiveness against armored units\n- Countered by Spearmen",
+  "description": "Fast cavalry effective at raiding, flanking, and countering ranged units.\n+ High movement speed\n+ Increased effectiveness against armored units\n- Countered by Spearmen",
   "classes": [
     "light",
     "melee",

--- a/units/delhi/ghazi-raider-4.json
+++ b/units/delhi/ghazi-raider-4.json
@@ -9,7 +9,7 @@
   "civs": [
     "de"
   ],
-  "description": "Fast cavalry effective at raiding, flanking, and countering ranged units.\n+ High movement speed\n- Increased effectiveness against armored units\n- Countered by Spearmen",
+  "description": "Fast cavalry effective at raiding, flanking, and countering ranged units.\n+ High movement speed\n+ Increased effectiveness against armored units\n- Countered by Spearmen",
   "classes": [
     "light",
     "melee",


### PR DESCRIPTION
`Increased effectiveness against armored units` should now be noted as a **positive** perk `+` rather than a **negative** perk `-`